### PR TITLE
Feature: add more to energym info output

### DIFF
--- a/gyms/energym/Dockerfile
+++ b/gyms/energym/Dockerfile
@@ -54,7 +54,6 @@ ADD . /app
 RUN pip3 install --upgrade pip
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git
-#RUN python -m pip install "git+https://github.com/bsl546/energym.git"
 
 WORKDIR /home
 RUN git clone "https://github.com/bsl546/energym.git" && cd energym \

--- a/gyms/energym/energymGymEnv.py
+++ b/gyms/energym/energymGymEnv.py
@@ -264,12 +264,12 @@ class EnergymGymEnv(gym.Env):
         reward = self.compute_reward(observations)
 
         # convert energym output observation to obs vector compatible with rllib
-        observations = self.obs_converter(observations)
+        conv_obs = self.obs_converter(observations)
 
-        # create dummy info variable, TBC what output we pass to user
-        info = {}
+        # create info with original observations
+        info = {"original_obs": observations}
 
-        return observations, reward, done, info
+        return conv_obs, reward, done, info
 
     def render(self):
         pass

--- a/gyms/energym/energymGymEnv.py
+++ b/gyms/energym/energymGymEnv.py
@@ -96,6 +96,7 @@ class EnergymGymEnv(gym.Env):
         normalize=True,
         discretize=False,
         discrete_bins=30,
+        ignore_reset=False,
     ):
 
         super().__init__()
@@ -119,6 +120,7 @@ class EnergymGymEnv(gym.Env):
         self.n_act = len(self.act_keys)
         self.temps = list(filter(lambda t: match("Z\d\d_T", t), self.obs_keys))
         self.power = ["Fa_Pw_All"]
+        self.ignore_reset = ignore_reset
 
         self.cont_actions = []
         self.discrete_actions = []
@@ -283,12 +285,15 @@ class EnergymGymEnv(gym.Env):
             obs (dict):
                 first observation from reset environment
         """
+        print(
+            f"Beobench: resetting environment. First reset completed: {self._first_reset_done}"
+        )
 
         # Prevent resetting Energym env twice on first call of reset()
         # as this appears to cause long simulations to run before resetting.
         # The issue is discussed here:
         # https://github.com/rdnfn/beobench/issues/43
-        if self._first_reset_done:
+        if self._first_reset_done and not self.ignore_reset:
             # on second or later reset, reset Energym env (but with warning)
             warnings.warn(
                 (

--- a/gyms/energym/energymGymEnv.py
+++ b/gyms/energym/energymGymEnv.py
@@ -97,6 +97,7 @@ class EnergymGymEnv(gym.Env):
         discretize=False,
         discrete_bins=30,
         ignore_reset=False,
+        populate_info=True,
     ):
 
         super().__init__()
@@ -121,6 +122,7 @@ class EnergymGymEnv(gym.Env):
         self.temps = list(filter(lambda t: match("Z\d\d_T", t), self.obs_keys))
         self.power = ["Fa_Pw_All"]
         self.ignore_reset = ignore_reset
+        self.populate_info = populate_info
 
         self.cont_actions = []
         self.discrete_actions = []
@@ -268,8 +270,19 @@ class EnergymGymEnv(gym.Env):
         # convert energym output observation to obs vector compatible with rllib
         conv_obs = self.obs_converter(observations)
 
-        # create info with original observations
-        info = {"original_obs": observations}
+        if self.populate_info:
+            # create info with original observations
+            flattened_acts = {
+                key: (
+                    value[0]
+                    if not isinstance(value[0], (list, np.ndarray))
+                    else value[0][0]
+                )
+                for key, value in action.items()
+            }
+            info = {"obs": observations, "acts": flattened_acts}
+        else:
+            info = {}
 
         return conv_obs, reward, done, info
 

--- a/gyms/energym/env_creator.py
+++ b/gyms/energym/env_creator.py
@@ -21,7 +21,7 @@ def create_env(env_config: dict = None) -> gym.Env:
         "SeminarcenterThermostat-v0": 10,
         "Apartments2Thermal-v0": 3,
         "MixedUseFanFCU-v0": 15,
-        # add remaining envs
+        # TODO add remaining envs
     }
 
     if not env_config:
@@ -34,6 +34,7 @@ def create_env(env_config: dict = None) -> gym.Env:
                 "step_period": 15,
                 "normalize": True,
                 "discretize": 30,
+                "ignore_reset": False,
             },
         }
 


### PR DESCRIPTION
This PR adds two main changes to Energym integration:
- Allow users to add full (unnormalised) observations and actions to `info` output of the `step()` function. This allows for comprehensive logging of episodes.
- Allow user to completely disable the reset functionality (in the sense of never actually resetting the simulation). RLlib sometimes appears to add `reset()` unpredicably, otherwise triggering long (useless) sim runs.

Thanks in advance for the review!

**Note:** this has been tested as part of https://github.com/rdnfn/beobench/pull/64.